### PR TITLE
WIP: enable sccache in builds

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -47,6 +47,11 @@ jobs:
     container:
       image: "rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-ubuntu22.04-py${{ matrix.PY_VER }}"
     steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 14400 # 4h
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -2,9 +2,13 @@
 
 set -e -E -u -o pipefail
 
+source rapids-configure-sccache
+
 rapids-print-env
 
 rapids-generate-version > ./VERSION
+
+sccache --zero-stats
 
 CMAKE_GENERATOR=Ninja \
 CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
@@ -18,6 +22,8 @@ rapids-conda-retry mambabuild \
     --channel nvidia \
     --no-force-upload \
     conda/recipes/legate-raft
+
+sccache --show-adv-stats
 
 # echo package details to logs, to help with debugging
 conda search \


### PR DESCRIPTION
Enables `sccache` in builds, to hopefully save some CI time, memory, and compute.