### PR TITLE
add shellcheck to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,8 +61,14 @@ repos:
         args:
           - --remove-empty-cells
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.17.1
+    rev: v1.18.1
     hooks:
       - id: rapids-dependency-file-generator
         args: [--clean]

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ PARALLEL_LEVEL=${PARALLEL_LEVEL:=`nproc`}
 
 # NOTE: ensure all dir changes are relative to the location of this
 # script, and that this script resides in the repo dir!
-REPODIR=$(cd $(dirname $0); pwd)
+REPODIR=$(cd "$(dirname "$0")"; pwd)
 
 BUILD_TYPE=Release
 BUILD_DIR="${REPODIR}/cpp/build/"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Adds `shellcheck` to `pre-commit`, to catch issues like unsafe access patterns, unused variables, etc. in shell scripts.

Fixes these warnings:

```text
SC2046 (warning): Quote this to prevent word splitting.
```